### PR TITLE
[Maint] Fix codecov: Add id-token: write to test job

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -19,6 +19,8 @@ jobs:
   test:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
+    permissions:
+      id-token: write  # needed for codecov OIDC authentication
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
Codecov is failing: https://github.com/napari/napari-geojson/actions/runs/24161610358/job/70514042222

It's probably the lack of token.