### PR TITLE
[maint] Fix some links for the repository org change from tdmorello to napari

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # napari-geojson
 
-[![License](https://img.shields.io/pypi/l/napari-geojson.svg?color=green)](https://github.com/tdmorello/napari-geojson/raw/main/LICENSE)
+[![License](https://img.shields.io/pypi/l/napari-geojson.svg?color=green)](https://github.com/napari/napari-geojson/raw/main/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/napari-geojson.svg?color=green)](https://pypi.org/project/napari-geojson)
 [![Python Version](https://img.shields.io/pypi/pyversions/napari-geojson.svg?color=green)](https://python.org)
-[![tests](https://github.com/tdmorello/napari-geojson/workflows/tests/badge.svg)](https://github.com/tdmorello/napari-geojson/actions)
-[![codecov](https://codecov.io/gh/tdmorello/napari-geojson/branch/main/graph/badge.svg)](https://codecov.io/gh/tdmorello/napari-geojson)
+[![tests](https://github.com/napari/napari-geojson/workflows/tests/badge.svg)](https://github.com/napari/napari-geojson/actions)
+[![codecov](https://codecov.io/gh/napari/napari-geojson/branch/main/graph/badge.svg)](https://codecov.io/gh/napari/napari-geojson)
 [![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/napari-geojson)](https://napari-hub.org/plugins/napari-geojson)
 
 Read and write geojson files in napari.
 
-![](https://github.com/tdmorello/napari-geojson/raw/main/resources/output.gif)
+![](https://github.com/napari/napari-geojson/raw/main/resources/output.gif)
 
 ----------------------------------
 
@@ -33,7 +33,7 @@ You can install `napari-geojson` via [pip]:
 
 To install latest development version :
 
-    pip install git+https://github.com/tdmorello/napari-geojson.git
+    pip install git+https://github.com/napari/napari-geojson.git
 
 
 ## Contributing
@@ -61,7 +61,7 @@ If you encounter any problems, please [file an issue] along with a detailed desc
 [Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt
 [cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin
 
-[file an issue]: https://github.com/tdmorello/napari-geojson/issues
+[file an issue]: https://github.com/napari/napari-geojson/issues
 
 [napari]: https://github.com/napari/napari
 [tox]: https://tox.readthedocs.io/en/latest/

--- a/README.md
+++ b/README.md
@@ -11,29 +11,26 @@ Read and write geojson files in napari.
 
 ![](https://github.com/napari/napari-geojson/raw/main/resources/output.gif)
 
-----------------------------------
-
-This [napari] plugin was generated with [Cookiecutter] using [@napari]'s [cookiecutter-napari-plugin] template.
-
-<!--
-Don't miss the full getting started guide to set up your new package:
-https://github.com/napari/cookiecutter-napari-plugin#getting-started
-
-and review the napari docs for plugin developers:
-https://napari.org/plugins/stable/index.html
--->
 
 ## Installation
 
-You can install `napari-geojson` via [pip]:
+You can install `napari-geojson` using the built-in napari plugin manager in the Plugins menu.
 
-    pip install napari-geojson
+Alternately, you can install `napari-geojson` via [pip]:
+```
+pip install napari-geojson
+```
 
 
+To install latest development version, use pip:
+```
+pip install git+https://github.com/napari/napari-geojson.git
+```
 
-To install latest development version :
-
-    pip install git+https://github.com/napari/napari-geojson.git
+Finally, you can also install from conda-forge using `conda`:
+```
+conda install -c conda-forge napari-geojson
+```
 
 
 ## Contributing
@@ -45,6 +42,10 @@ the coverage at least stays the same before you submit a pull request.
 
 Distributed under the terms of the [BSD-3] license,
 "napari-geojson" is free and open source software
+
+## Attribution
+
+This plugin was originally developed and maintained by [Tim Morello](https://github.com/tdmorello). In April 2026, the plugin was moved to the napari organization and is now developed and maintained by the napari team.
 
 ## Issues
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dependencies = [
 ]
 
 [project.urls]
-homepage = "https://github.com/tdmorello/napari-geojson"
-repository = "https://github.com/tdmorello/napari-geojson"
+homepage = "https://github.com/napari/napari-geojson"
+repository = "https://github.com/napari/napari-geojson"
 
 
 [project.entry-points."napari.manifest"]


### PR DESCRIPTION
Fix links in the README and pyproject.toml that I missed in #15 