### PR TITLE
[maint] Use py310 as minimum to match napari (ensures support for 0.6.x and 0.7.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "napari-geojson"
 description = "Read and write geojson files in napari"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     { name = "Tim Morello", email = "tdmorello@gmail.com" },
     { name = "napari team", email = "napari-steering-council@googlegroups.com" },
@@ -21,8 +21,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{311,312,313,314}-{linux,macos,windows}
+envlist = py{310,311,312,313,314}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
+    3.10: py310
     3.11: py311
     3.12: py312
     3.13: py313


### PR DESCRIPTION
Followup to #15 

Opted for 3.10 as the minimum to match napari and ensure support back to 0.6.0.