### PR TITLE
Warn on invalid geojson that is a bare list of features

### DIFF
--- a/src/napari_geojson/_reader.py
+++ b/src/napari_geojson/_reader.py
@@ -48,13 +48,14 @@ def geojson_to_napari(fname: str) -> list[tuple[Any, dict, str]]:
         collection = data.geometries
     elif isinstance(data, (geojson.Feature, Geometry)):
         collection = [data]
-    # TODO remove this
+    # NOTE: Invalid geojson will be removed in 0.2.0
     # this is handling invalid geojson which was produced before 0.1.5
     else:
         warnings.warn(
             (
-                "Invalid GeoJSON. Reading top-level GeoJSON values other than a Geometry, Feature, "
-                "FeatureCollection will be removed in 0.2.0 release. "
+                "Invalid GeoJSON. Reading a non-standard top-level GeoJSON value (supported for backward compatibility with pre-0.1.5 output). "
+                "Please use a Feature Collection, Geometry, or Feature. "
+                "This fallback behavior will be removed in v0.2.0. "
             ),
             FutureWarning,
             stacklevel=2,

--- a/src/napari_geojson/_reader.py
+++ b/src/napari_geojson/_reader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
@@ -45,12 +46,20 @@ def geojson_to_napari(fname: str) -> list[tuple[Any, dict, str]]:
         collection = data.features
     elif isinstance(data, geojson.GeometryCollection):
         collection = data.geometries
-    # TODO remove this
-    # this is handling invalid geojson which currently the plugin produces
-    elif isinstance(data, (list, tuple)):
-        collection = data
-    else:
+    elif isinstance(data, (geojson.Feature, Geometry)):
         collection = [data]
+    # TODO remove this
+    # this is handling invalid geojson which was produced before 0.1.5
+    else:
+        warnings.warn(
+            (
+                "Invalid GeoJSON. Reading top-level GeoJSON values other than a Geometry, Feature, "
+                "FeatureCollection will be removed in 0.2.0 release. "
+            ),
+            FutureWarning,
+            stacklevel=2,
+        )
+        collection = data
 
     layer_data = []
 

--- a/tests/test_data/invalid_feature_list.geojson
+++ b/tests/test_data/invalid_feature_list.geojson
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [1, 2]
+    },
+    "properties": {
+      "name": "point-a"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [3, 4]
+    },
+    "properties": {
+      "name": "point-b"
+    }
+  }
+]

--- a/tests/test_data/single_feature.geojson
+++ b/tests/test_data/single_feature.geojson
@@ -1,0 +1,10 @@
+{
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [1, 2]
+  },
+  "properties": {
+    "name": "single-point"
+  }
+}

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -64,7 +64,7 @@ def test_read_bare_feature_list_with_deprecation(read_test_data):
     """Reader emits warning for invalid top-level feature lists."""
     with pytest.warns(
         FutureWarning,
-        match="Invalid GeoJSON. Reading top-level GeoJSON values other than",
+        match="Invalid GeoJSON. Reading a non-standard top-level GeoJSON",
     ):
         layer_data_list = read_test_data("invalid_feature_list.geojson")
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,6 +1,7 @@
 """Tests for the reader part of the plugin."""
 
 import numpy as np
+import pytest
 
 
 def test_read_feature_collection_test_data(read_test_data):
@@ -45,6 +46,34 @@ def test_read_geometry_collection_test_data(read_test_data):
         shapes[1],
         np.array([[14, 13], [14, 15], [16, 15], [14, 13]]),
     )
+
+
+def test_read_single_feature_test_data_without_deprecation(read_test_data):
+    """Reader accepts a single valid top-level Feature."""
+    layer_data_list = read_test_data("single_feature.geojson")
+
+    assert [layer[2] for layer in layer_data_list] == ["points"]
+
+    points, point_meta, kind = layer_data_list[0]
+    assert kind == "points"
+    np.testing.assert_array_equal(points, np.array([2, 1]))
+    assert point_meta["properties"]["name"] == ["single-point"]
+
+
+def test_read_bare_feature_list_with_deprecation(read_test_data):
+    """Reader emits warning for invalid top-level feature lists."""
+    with pytest.warns(
+        FutureWarning,
+        match="Invalid GeoJSON. Reading top-level GeoJSON values other than",
+    ):
+        layer_data_list = read_test_data("invalid_feature_list.geojson")
+
+    assert [layer[2] for layer in layer_data_list] == ["points"]
+
+    points, point_meta, kind = layer_data_list[0]
+    assert kind == "points"
+    np.testing.assert_array_equal(points, np.array([[2, 1], [4, 3]]))
+    assert point_meta["properties"]["name"] == ["point-a", "point-b"]
 
 
 def test_read_qupath_geojson_test_data(read_test_data):


### PR DESCRIPTION
Followup to https://github.com/napari/napari-geojson/pull/27 and https://github.com/napari/napari-geojson/pull/20

In #20 we added tests for various valid geojson.
In #27, we ensure that the plugin writes valid geojson.
In this PR, add a warning for reading the invalid geojson that the plugin previously wrote (and ones that QuPath can optionally write -- but not by default).
I also add an extra test for a valid single-Feature geojson and a test with an invalid list of Features.

My thought here is that with this can make a 0.1.5 release.
