### PR TITLE
Ensure Polygons are read/written according to spec as rings

### DIFF
--- a/src/napari_geojson/_reader.py
+++ b/src/napari_geojson/_reader.py
@@ -99,7 +99,18 @@ def geojson_to_napari(fname: str) -> list[tuple[Any, dict, str]]:
 
 def get_shape(geom: Geometry) -> list:
     """Return coordinates of shapes."""
-    return get_coords(geom)
+    coords = get_coords(geom)
+    # Strip closing coordinate for polygons
+    # GeoJSON requires closed rings per RFC 7946 §3.1.6
+    # but napari expects just vertex coordinates
+    geom_type = geom.geometry.type if geom.type == "Feature" else geom.type
+    if (
+        geom_type == "Polygon"
+        and len(coords) > 1
+        and np.array_equal(coords[0], coords[-1])
+    ):
+        coords = coords[:-1]
+    return coords
 
 
 def get_coords(geom: Geometry, flipxy=True) -> list:

--- a/src/napari_geojson/_writer.py
+++ b/src/napari_geojson/_writer.py
@@ -65,11 +65,17 @@ def format_qupath(shape, object_type="annotation", is_locked=False):
 def get_geometry(coords: list, shape_type: str, flipxy=True) -> Polygon | LineString:
     """Get GeoJSON type geometry from napari shape."""
     if shape_type in ["rectangle", "polygon"]:
+        # Close the ring per GeoJSON spec (RFC 7946 §3.1.6)
+        if coords[0] != coords[-1]:
+            coords = coords + [coords[0]]
         shape = Polygon(coords)
     elif shape_type in ["line", "path"]:
         shape = LineString(coords)
     elif shape_type == "ellipse":
-        shape = Polygon(ellipse_to_polygon(coords))
+        poly_coords = ellipse_to_polygon(coords)
+        if poly_coords[0] != poly_coords[-1]:
+            poly_coords = poly_coords + [poly_coords[0]]
+        shape = Polygon(poly_coords)
     else:
         raise ValueError(f"Shape type `{shape_type}` not supported.")
     if flipxy:

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -22,7 +22,7 @@ def test_read_feature_collection_test_data(read_test_data):
     np.testing.assert_array_equal(shapes[0], np.array([[20, 10], [40, 30]]))
     np.testing.assert_array_equal(
         shapes[1],
-        np.array([[200, 100], [200, 110], [210, 110], [200, 100]]),
+        np.array([[200, 100], [200, 110], [210, 110]]),
     )
 
 
@@ -44,7 +44,7 @@ def test_read_geometry_collection_test_data(read_test_data):
     np.testing.assert_array_equal(shapes[0], np.array([[10, 9], [12, 11]]))
     np.testing.assert_array_equal(
         shapes[1],
-        np.array([[14, 13], [14, 15], [16, 15], [14, 13]]),
+        np.array([[14, 13], [14, 15], [16, 15]]),
     )
 
 
@@ -118,14 +118,7 @@ def test_read_3d_coordinates_reverse_axis_order(read_test_data):
     )
     np.testing.assert_array_equal(
         shapes[1],
-        np.array(
-            [
-                [60, 50, 40],
-                [60, 50, 41],
-                [61, 51, 41],
-                [60, 50, 40],
-            ]
-        ),
+        np.array([[60, 50, 40], [60, 50, 41], [61, 51, 41]]),
     )
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -7,10 +7,10 @@ from napari_geojson._writer import write_shapes
 
 sample_shapes = [
     ([[0, 0], [0, 5], [5, 5], [5, 0]], "ellipse", "Polygon"),
-    ([[0, 0], [5, 5]], "line", "LineString"),
     ([[0, 0], [5, 5], [0, 10]], "polygon", "Polygon"),
-    ([[0, 0], [5, 5], [0, 10]], "path", "LineString"),
     ([[0, 0], [0, 5], [5, 5], [5, 0]], "rectangle", "Polygon"),
+    ([[0, 0], [5, 5]], "line", "LineString"),
+    ([[0, 0], [5, 5], [0, 10]], "path", "LineString"),
 ]
 
 
@@ -31,9 +31,11 @@ def test_write_shapes_outputs_feature_collection(tmp_path):
         collection = geojson.load(fp)
 
     assert isinstance(collection, geojson.FeatureCollection)
-    actual_geom_types = [
-        feature["geometry"]["type"] for feature in collection.features
-    ]
+    actual_geom_types = [feature["geometry"]["type"] for feature in collection.features]
     expected_geom_types = [shape[2] for shape in sample_shapes]
-
     assert actual_geom_types == expected_geom_types
+
+    # check that polygons written out are closed rings
+    for geom in collection.features[:-2]:
+        coords = np.array(list(geojson.utils.coords(geom)))
+        assert np.array_equal(coords[0], coords[-1])


### PR DESCRIPTION
closes: https://github.com/napari/napari-geojson/issues/10
**important**: this only handles conventional polygons, not ones with holes. The logic there still needs work! (see https://github.com/napari/napari-geojson/issues/9)

geojson polygons must be rings, so the first and last coordinate must match.
napari handling of rings is tricky. napari can handle this for single polygons, with a hack (https://github.com/napari/napari/pull/7942), but native napari shapes are not rings...
...unless they have holes, then they are rings.

In this PR I ensure that at least for Shapes created using GUI (so no holes, just regular polygons), they are saved as rings to the GeoJSON. Then, when read back into napari the extra vertex is stripped.
We could leave this vertex in (thanks to https://github.com/napari/napari/pull/7942), but I think most napari users will expect e.g. a triangle to only have 3 vertexes, so on. So I rather have a separation on the io boundary between napari and geojson polygons.

I tweaked the test to account for the new behavior.

At the end of the day, with this PR you can draw polygons in napari app and save a geojson that is valid and can be opened in e.g. QuPath. so napari -> qupath now works.
qupath -> napari -> qupath is unaffected.