### PR TITLE
Refactor coordinate flipping between GeoJSON and napari

### DIFF
--- a/src/napari_geojson/_reader.py
+++ b/src/napari_geojson/_reader.py
@@ -97,10 +97,11 @@ def geojson_to_napari(fname: str) -> list[tuple[Any, dict, str]]:
 
 
 def get_coords(geom: Geometry) -> np.ndarray:
-    """Convert geojson geometry coordinates to napari numpy arrays.
+    """Convert GeoJSON geometry coordinates to napari numpy arrays.
 
-    GeoJSON is always in ZY(Z optional) order, but napari expects ZYX order,
-    so reverse the order of the last dimension of the coordinates.
+    GeoJSON is always in XY(Z optional) order (longitude, latitude,
+    altitude), but napari expects ZYX order, so reverse the order of
+    the last dimension of the coordinates.
     """
     coords = np.array(list(geojson.utils.coords(geom)))
     # Strip closing coordinate for polygons

--- a/src/napari_geojson/_reader.py
+++ b/src/napari_geojson/_reader.py
@@ -36,7 +36,6 @@ def reader_function(path) -> list["napari.types.LayerDataTuple"]:
     return layer_data_tuples
 
 
-# TODO if all objects are point, load into points layer?
 def geojson_to_napari(fname: str) -> list[tuple[Any, dict, str]]:
     """Convert geojson into napari shapes data."""
     with open(fname) as f:
@@ -79,7 +78,7 @@ def geojson_to_napari(fname: str) -> list[tuple[Any, dict, str]]:
             shape_geoms.append(geom)
             shape_types.append(shape_type)
 
-    # create a point layer for each multipoint layer in the data
+    # create a point layer for each multipoint feature in the data
     for geom in multi_point_geoms:
         layer_data.append(create_point_layer_data([geom]))
 
@@ -87,9 +86,9 @@ def geojson_to_napari(fname: str) -> list[tuple[Any, dict, str]]:
     if point_geoms:
         layer_data.append(create_point_layer_data(point_geoms))
 
-    # create a shape layer for all other shape geometries
+    # create a single shape layer for all other shape geometries
     if shape_geoms:
-        shapes = [get_shape(geom) for geom in shape_geoms]
+        shapes = [get_coords(geom) for geom in shape_geoms]
         properties = get_properties(shape_geoms)
         meta = {"shape_type": shape_types, "properties": properties}
         layer_data.append((shapes, meta, "shapes"))
@@ -97,9 +96,13 @@ def geojson_to_napari(fname: str) -> list[tuple[Any, dict, str]]:
     return layer_data
 
 
-def get_shape(geom: Geometry) -> list:
-    """Return coordinates of shapes."""
-    coords = get_coords(geom)
+def get_coords(geom: Geometry) -> np.ndarray:
+    """Convert geojson geometry coordinates to napari numpy arrays.
+
+    GeoJSON is always in ZY(Z optional) order, but napari expects ZYX order,
+    so reverse the order of the last dimension of the coordinates.
+    """
+    coords = np.array(list(geojson.utils.coords(geom)))
     # Strip closing coordinate for polygons
     # GeoJSON requires closed rings per RFC 7946 §3.1.6
     # but napari expects just vertex coordinates
@@ -110,19 +113,15 @@ def get_shape(geom: Geometry) -> list:
         and np.array_equal(coords[0], coords[-1])
     ):
         coords = coords[:-1]
-    return coords
 
-
-def get_coords(geom: Geometry, flipxy=True) -> list:
-    """Return coordinates for geojson shapes."""
-    coords = np.array(list(geojson.utils.coords(geom)))
-    if flipxy:
-        coords = np.flip(coords, 1)
-    return coords
+    return coords[..., ::-1]
 
 
 def create_point_layer_data(collection) -> tuple[Any, dict, str]:
-    pts = np.squeeze([get_shape(geom) for geom in collection])
+    pts = np.concatenate(
+        [np.atleast_2d(get_coords(geom)) for geom in collection],
+        axis=0,
+    )
     pt_properties = get_properties(collection)
     pt_meta = {"properties": pt_properties}
     return (pts, pt_meta, "points")
@@ -130,7 +129,6 @@ def create_point_layer_data(collection) -> tuple[Any, dict, str]:
 
 def get_shape_type(geom: Geometry) -> str:
     """Translate geojson to napari shape notation."""
-    # QuPath stores 'type' under 'geometry'
     if geom.type == "Feature":
         geom_type = geom.geometry.type
     else:

--- a/src/napari_geojson/_reader.py
+++ b/src/napari_geojson/_reader.py
@@ -102,6 +102,17 @@ def get_coords(geom: Geometry) -> np.ndarray:
     GeoJSON is always in XY(Z optional) order (longitude, latitude,
     altitude), but napari expects ZYX order, so reverse the order of
     the last dimension of the coordinates.
+
+    Parameters
+    ----------
+    geom : Geometry
+        GeoJSON geometry object, which has coordinates in longitude,
+        latitude, altitude order, corresponding to XY(Z optional).
+
+    Returns
+    -------
+    np.ndarray
+        An array of coordinates in ZYX order, suitable for napari.
     """
     coords = np.array(list(geojson.utils.coords(geom)))
     # Strip closing coordinate for polygons

--- a/src/napari_geojson/_writer.py
+++ b/src/napari_geojson/_writer.py
@@ -29,7 +29,7 @@ def write_shapes(path: str, layer_data: list[FullLayerData]) -> str:
                 features.extend(
                     [
                         geojson.Feature(geometry=get_geometry(s, t), properties={})
-                        for s, t in zip(data, meta["shape_type"])  # noqa E501
+                        for s, t in zip(data, meta["shape_type"])
                     ]
                 )
 
@@ -40,7 +40,7 @@ def write_shapes(path: str, layer_data: list[FullLayerData]) -> str:
 def reverse_axis_order(coords: ArrayLike) -> np.ndarray:
     """Reverse coordinate axis order along the last dimension.
 
-    Ensures that napari ZYX order is converted to GeoJSON XY(Z optional)
+    Ensures that napari (Z)YX order is converted to GeoJSON XY(Z optional)
     order.
     """
     return np.asarray(coords)[..., ::-1]
@@ -48,12 +48,13 @@ def reverse_axis_order(coords: ArrayLike) -> np.ndarray:
 
 def get_geometry(coords: ArrayLike, shape_type: str) -> Polygon | LineString:
     """Convert napari coordinates to a GeoJSON geometry."""
-    if shape_type in ["rectangle", "polygon"]:
+    if shape_type == "ellipse":
+        coords = ellipse_to_polygon(coords)
+
+    if shape_type in ["rectangle", "polygon", "ellipse"]:
         # Close the ring per GeoJSON spec (RFC 7946 §3.1.6)
         if not np.array_equal(coords[0], coords[-1]):
             coords = np.vstack([coords, coords[0]])
-    if shape_type == "ellipse":
-        coords = ellipse_to_polygon(coords)
 
     coords = reverse_axis_order(coords).tolist()
 

--- a/src/napari_geojson/_writer.py
+++ b/src/napari_geojson/_writer.py
@@ -2,94 +2,70 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import geojson
-from geojson.geometry import Geometry, LineString, MultiPoint, Polygon
+import numpy as np
+from geojson.geometry import LineString, MultiPoint, Polygon
 from napari.layers.shapes._shapes_models import Ellipse
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
-    DataType = Any | Sequence[Any]
-    FullLayerData = tuple[DataType, dict, str]
+    from napari.types import FullLayerData
+    from numpy.typing import ArrayLike
 
 
-def write_shapes(path: str, layer_data: list[tuple[Any, dict, str]]) -> str:
-    """Write a single geojson file from napari shape layer data."""
+def write_shapes(path: str, layer_data: list[FullLayerData]) -> str:
+    """Write a single geojson file from napari shape and point layer data."""
     with open(path, "w") as fp:
-        shapes = []
+        features = []
         for layer in layer_data:
             data, meta, kind = layer
             if kind == "points":
-                shapes.append(MultiPoint([list(p) for p in data]))
+                points = np.atleast_2d(reverse_axis_order(data)).tolist()
+                features.append(
+                    geojson.Feature(geometry=MultiPoint(points), properties={})
+                )
             else:
-                shapes.extend(
+                features.extend(
                     [
-                        get_geometry(s.tolist(), t)
+                        geojson.Feature(geometry=get_geometry(s, t), properties={})
                         for s, t in zip(data, meta["shape_type"])  # noqa E501
                     ]
                 )
 
-        # convert shapes into QuPath friendly format
-        shapes = [format_qupath(s) for s in shapes]
-
-        geojson.dump(geojson.FeatureCollection(shapes), fp)
+        geojson.dump(geojson.FeatureCollection(features), fp)
         return fp.name
 
 
-# TODO make explicit about how to change coordinates... it works for QuPath for now
-def flip_coords(geom: Geometry, flipxy=True) -> list:
-    """Return coordinates for geojson shapes."""
-    if geom["type"] == "Point":
-        geom["coordinates"].reverse()
-        return geom
-    else:
-        for c in geom["coordinates"]:
-            c.reverse()
-    return geom
+def reverse_axis_order(coords: ArrayLike) -> np.ndarray:
+    """Reverse coordinate axis order along the last dimension.
+
+    Ensures that napari ZYX order is converted to GeoJSON XY(Z optional)
+    order.
+    """
+    return np.asarray(coords)[..., ::-1]
 
 
-def format_qupath(shape, object_type="annotation", is_locked=False):
-    """Convert to QuPath friendly object format."""
-    shape = {
-        "type": "Feature",
-        "geometry": shape,
-        "properties": {"object_type": object_type, "isLocked": is_locked},
-    }
-    if shape["geometry"]["type"] == "Polygon":
-        shape["geometry"]["coordinates"] = [shape["geometry"]["coordinates"]]
-    return shape
-
-
-def get_geometry(coords: list, shape_type: str, flipxy=True) -> Polygon | LineString:
-    """Get GeoJSON type geometry from napari shape."""
+def get_geometry(coords: ArrayLike, shape_type: str) -> Polygon | LineString:
+    """Convert napari coordinates to a GeoJSON geometry."""
     if shape_type in ["rectangle", "polygon"]:
         # Close the ring per GeoJSON spec (RFC 7946 §3.1.6)
-        if coords[0] != coords[-1]:
-            coords = coords + [coords[0]]
-        shape = Polygon(coords)
-    elif shape_type in ["line", "path"]:
-        shape = LineString(coords)
-    elif shape_type == "ellipse":
-        poly_coords = ellipse_to_polygon(coords)
-        if poly_coords[0] != poly_coords[-1]:
-            poly_coords = poly_coords + [poly_coords[0]]
-        shape = Polygon(poly_coords)
-    else:
-        raise ValueError(f"Shape type `{shape_type}` not supported.")
-    if flipxy:
-        shape = flip_coords(shape)
-    return shape
+        if not np.array_equal(coords[0], coords[-1]):
+            coords = np.vstack([coords, coords[0]])
+    if shape_type == "ellipse":
+        coords = ellipse_to_polygon(coords)
+
+    coords = reverse_axis_order(coords).tolist()
+
+    if shape_type in ["rectangle", "polygon", "ellipse"]:
+        return Polygon([coords])
+    if shape_type in ["line", "path"]:
+        return LineString(coords)
+    raise ValueError(f"Shape type `{shape_type}` not supported.")
 
 
-def get_points(coords: list) -> MultiPoint:
-    """Get GeoJSON MultiPoints from napari points layer."""
-    ...
-
-
-def ellipse_to_polygon(coords: list) -> list:
+def ellipse_to_polygon(coords: ArrayLike) -> np.ndarray:
     """Convert an ellipse to a polygon."""
     # TODO implement custom function
     # Hacky way to use napari's internal conversion
-    return Ellipse(coords)._edge_vertices.tolist()
+    return Ellipse(np.asarray(coords))._edge_vertices

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -56,7 +56,7 @@ def test_read_single_feature_test_data_without_deprecation(read_test_data):
 
     points, point_meta, kind = layer_data_list[0]
     assert kind == "points"
-    np.testing.assert_array_equal(points, np.array([2, 1]))
+    np.testing.assert_array_equal(points, np.array([[2, 1]]))
     assert point_meta["properties"]["name"] == ["single-point"]
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -47,3 +47,24 @@ def test_write_shapes_outputs_feature_collection(tmp_path):
         actual = np.array(list(geojson.utils.coords(feature)))
         assert actual.shape == expected.shape
         assert np.array_equal(actual, expected)
+
+
+def test_write_points_outputs_multipoint_feature(tmp_path):
+    """Test a napari Points layer written as a GeoJSON MultiPoint feature."""
+    fname = tmp_path / "points.geojson"
+    points = np.array([[2, 1], [1, 2]])
+    layer_data = [(points, {}, "points")]
+
+    write_shapes(str(fname), layer_data)
+
+    with open(fname) as fp:
+        collection = geojson.load(fp)
+
+    assert isinstance(collection, geojson.FeatureCollection)
+    assert len(collection.features) == 1
+    feature = collection.features[0]
+    assert feature["geometry"]["type"] == "MultiPoint"
+    np.testing.assert_array_equal(
+        np.asarray(feature["geometry"]["coordinates"]),
+        points[..., ::-1],
+    )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -9,13 +9,13 @@ sample_shapes = [
     ([[0, 0], [0, 5], [5, 5], [5, 0]], "ellipse", "Polygon"),
     ([[0, 0], [5, 5], [0, 10]], "polygon", "Polygon"),
     ([[0, 0], [0, 5], [5, 5], [5, 0]], "rectangle", "Polygon"),
-    ([[0, 0], [5, 5]], "line", "LineString"),
+    ([[0, 5], [5, 0]], "line", "LineString"),
     ([[0, 0], [5, 5], [0, 10]], "path", "LineString"),
 ]
 
 
 def test_write_shapes_outputs_feature_collection(tmp_path):
-    """Writer writes all shapes as a single GeoJSON FeatureCollection."""
+    """Writer writes standard GeoJSON Features inside one FeatureCollection."""
     fname = tmp_path / "sample.geojson"
     layer_data = [
         (
@@ -39,3 +39,11 @@ def test_write_shapes_outputs_feature_collection(tmp_path):
     for geom in collection.features[:-2]:
         coords = np.array(list(geojson.utils.coords(geom)))
         assert np.array_equal(coords[0], coords[-1])
+
+    # Verify GeoJSON coordinates are in XY (Z optional) order — reversed from napari ZYX
+    for shape, feature in zip(sample_shapes[-2:], collection.features[-2:]):
+        napari_coords = np.asarray(shape[0])
+        expected = napari_coords[..., ::-1]
+        actual = np.array(list(geojson.utils.coords(feature)))
+        assert actual.shape == expected.shape
+        assert np.array_equal(actual, expected)


### PR DESCRIPTION
Closes: https://github.com/napari/napari-geojson/issues/22

GeoJSON is always in XY(Z optional) order (longitude, latitude, altitude), but napari expects ZYX order, so we need to ensure that we reverse the order of the last dimension of coordinates on read, but then reverse back on write.

There was a partial implementation already, but it was focused on QuPath and incomplete. Here I focus on trying to simplify and just focus on the GeoJSON spec. Most of the QuPath specific things were removed, but they have no adverse effect on compatibility -- I checked, it handles generic GeoJSON and has reasonable defaults.

Note: polygons with holes are still not handled correctly!