### PR TITLE
Refactor _writer to handle polygons with holes properly: split the flat array to rings

### DIFF
--- a/src/napari_geojson/_writer.py
+++ b/src/napari_geojson/_writer.py
@@ -50,19 +50,83 @@ def get_geometry(coords: ArrayLike, shape_type: str) -> Polygon | LineString:
     """Convert napari coordinates to a GeoJSON geometry."""
     if shape_type == "ellipse":
         coords = ellipse_to_polygon(coords)
+        return Polygon(coords.tolist())
 
-    if shape_type in ["rectangle", "polygon", "ellipse"]:
-        # Close the ring per GeoJSON spec (RFC 7946 §3.1.6)
-        if not np.array_equal(coords[0], coords[-1]):
-            coords = np.vstack([coords, coords[0]])
+    if shape_type in ["rectangle", "polygon"]:
+        return Polygon([ring.tolist() for ring in get_polygon_rings(coords)])
 
     coords = reverse_axis_order(coords).tolist()
 
-    if shape_type in ["rectangle", "polygon", "ellipse"]:
-        return Polygon([coords])
     if shape_type in ["line", "path"]:
         return LineString(coords)
     raise ValueError(f"Shape type `{shape_type}` not supported.")
+
+
+def get_polygon_rings(coords: ArrayLike) -> list[np.ndarray]:
+    """Convert flat napari polygon vertices into GeoJSON linear rings.
+
+    For polygons with holes, napari represents a polygon as a flat array of
+    vertices where each ring is terminated by repeating the first vertex.
+    GeoJSON requires separate linear rings: exterior first, then holes.
+    """
+    coords = np.atleast_2d(np.asarray(coords))
+    rings = _split_rings(coords)
+    geojson_rings = [reverse_axis_order(ring) for ring in rings]
+    exterior, *holes = geojson_rings
+    return [orient_linear_ring(exterior, exterior=True)] + [
+        orient_linear_ring(ring, exterior=False) for ring in holes
+    ]
+
+
+def _split_rings(coords: np.ndarray) -> list[np.ndarray]:
+    """Split a flat vertex array into individual closed linear rings."""
+    rings = []
+    start = 0
+    for end in range(1, len(coords)):
+        if end - start >= 3 and np.array_equal(coords[end], coords[start]):
+            rings.append(close_linear_ring(coords[start : end + 1]))
+            start = end + 1
+    if start < len(coords):
+        rings.append(close_linear_ring(coords[start:]))
+    return rings
+
+
+def close_linear_ring(coords: np.ndarray) -> np.ndarray:
+    """Ensure ring is explicitly closed as per GeoJSON spec (RFC 7946 §3.1.6)."""
+    if len(coords) < 3:
+        raise ValueError("Polygon rings require at least three coordinates.")
+    if not np.array_equal(coords[0], coords[-1]):
+        coords = np.vstack([coords, coords[0]])
+    return coords
+
+
+def orient_linear_ring(coords: np.ndarray, exterior: bool) -> np.ndarray:
+    """Orient a GeoJSON linear ring to match requirement of RFC 7946 §3.1.6.
+
+    In GeoJSON, the exterior ring of a polygon must be counterclockwise
+    and holes must be clockwise.
+    """
+    orientation = linear_ring_orientation(coords)
+
+    return coords if orientation == exterior else coords[::-1]
+
+
+def linear_ring_orientation(coords: np.ndarray) -> bool:
+    """Return the orientation of a closed linear ring in GeoJSON XY space.
+
+    Uses the shoelace formula to compute the signed area:
+    - True (positive signed area) indicates counterclockwise orientation (exterior ring in GeoJSON)
+    - False (negative signed area) indicates clockwise orientation (hole in GeoJSON)
+    """
+    coords = np.atleast_2d(np.asarray(coords, dtype=float))
+    if coords.shape[1] < 2:
+        raise ValueError("Polygon coordinates must have at least two dimensions.")
+
+    x, next_x = coords[:-1, 0], coords[1:, 0]
+    y, next_y = coords[:-1, 1], coords[1:, 1]
+    signed_area = float(0.5 * np.sum(x * next_y - next_x * y))
+
+    return signed_area > 0
 
 
 def ellipse_to_polygon(coords: ArrayLike) -> np.ndarray:

--- a/src/napari_geojson/_writer.py
+++ b/src/napari_geojson/_writer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import geojson
@@ -21,14 +22,14 @@ def write_shapes(path: str, layer_data: list[FullLayerData]) -> str:
         for layer in layer_data:
             data, meta, kind = layer
             if kind == "points":
-                points = np.atleast_2d(reverse_axis_order(data)).tolist()
+                points = np.atleast_2d(_reverse_axis_order(data)).tolist()
                 features.append(
                     geojson.Feature(geometry=MultiPoint(points), properties={})
                 )
             else:
                 features.extend(
                     [
-                        geojson.Feature(geometry=get_geometry(s, t), properties={})
+                        geojson.Feature(geometry=_get_geometry(s, t), properties={})
                         for s, t in zip(data, meta["shape_type"])
                     ]
                 )
@@ -37,7 +38,7 @@ def write_shapes(path: str, layer_data: list[FullLayerData]) -> str:
         return fp.name
 
 
-def reverse_axis_order(coords: ArrayLike) -> np.ndarray:
+def _reverse_axis_order(coords: ArrayLike) -> np.ndarray:
     """Reverse coordinate axis order along the last dimension.
 
     Ensures that napari (Z)YX order is converted to GeoJSON XY(Z optional)
@@ -46,16 +47,16 @@ def reverse_axis_order(coords: ArrayLike) -> np.ndarray:
     return np.asarray(coords)[..., ::-1]
 
 
-def get_geometry(coords: ArrayLike, shape_type: str) -> Polygon | LineString:
+def _get_geometry(coords: ArrayLike, shape_type: str) -> Polygon | LineString:
     """Convert napari coordinates to a GeoJSON geometry."""
     if shape_type == "ellipse":
-        coords = ellipse_to_polygon(coords)
+        coords = _ellipse_to_polygon(coords)
         return Polygon(coords.tolist())
 
     if shape_type in ["rectangle", "polygon"]:
         return Polygon([ring.tolist() for ring in get_polygon_rings(coords)])
 
-    coords = reverse_axis_order(coords).tolist()
+    coords = _reverse_axis_order(coords).tolist()
 
     if shape_type in ["line", "path"]:
         return LineString(coords)
@@ -70,48 +71,79 @@ def get_polygon_rings(coords: ArrayLike) -> list[np.ndarray]:
     GeoJSON requires separate linear rings: exterior first, then holes.
     """
     coords = np.atleast_2d(np.asarray(coords))
-    rings = _split_rings(coords)
-    geojson_rings = [reverse_axis_order(ring) for ring in rings]
-    exterior, *holes = geojson_rings
-    return [orient_linear_ring(exterior, exterior=True)] + [
-        orient_linear_ring(ring, exterior=False) for ring in holes
+    return [
+        _orient_linear_ring(_reverse_axis_order(ring), exterior=index == 0)
+        for index, ring in enumerate(_split_rings(coords))
     ]
 
 
 def _split_rings(coords: np.ndarray) -> list[np.ndarray]:
-    """Split a flat vertex array into individual closed linear rings."""
+    """Split a flat vertex array into individual closed linear rings.
+
+    napari stores polygons with holes as a flat list of vertices where each
+    closed ring repeats its first vertex.
+    If no ring terminator is present, the full array is treated as a single ring.
+    After a series of rings, an optional path terminator may be present, but is
+    silently trimmed.
+    Any other trailing vertices are trimmed with a warning because they do not define a
+    valid ring and result in bizarre output that is also not valid GeoJSON. See:
+    https://github.com/napari/napari/issues/9013
+    """
     rings = []
     start = 0
     for end in range(1, len(coords)):
         if end - start >= 3 and np.array_equal(coords[end], coords[start]):
-            rings.append(close_linear_ring(coords[start : end + 1]))
+            rings.append(_close_linear_ring(coords[start : end + 1]))
             start = end + 1
-    if start < len(coords):
-        rings.append(close_linear_ring(coords[start:]))
+
+    remainder = coords[start:]
+    # all rings closed
+    if len(remainder) == 0:
+        return rings
+    # no closed rings, so treat as single ring and close it
+    if not rings:
+        return [_close_linear_ring(remainder)]
+    # path-closing vertex present, silently ignore it
+    if len(remainder) == 1 and np.array_equal(remainder[0], rings[0][0]):
+        return rings
+    # Extra invalid vertices present
+    warnings.warn(
+        (
+            "Ignoring trailing polygon vertices after closed rings because "
+            "they do not form a valid GeoJSON linear ring."
+        ),
+        UserWarning,
+        stacklevel=2,
+    )
     return rings
 
 
-def close_linear_ring(coords: np.ndarray) -> np.ndarray:
-    """Ensure ring is explicitly closed as per GeoJSON spec (RFC 7946 §3.1.6)."""
+def _close_linear_ring(coords: np.ndarray) -> np.ndarray:
+    """Return a valid GeoJSON linear ring, closing it if needed."""
+    coords = np.atleast_2d(np.asarray(coords))
+    # Check if already closed
+    if np.array_equal(coords[0], coords[-1]):
+        if len(coords) < 4:
+            raise ValueError("GeoJSON linear rings require at least four positions.")
+        return coords
+
     if len(coords) < 3:
         raise ValueError("Polygon rings require at least three coordinates.")
-    if not np.array_equal(coords[0], coords[-1]):
-        coords = np.vstack([coords, coords[0]])
-    return coords
+
+    return np.vstack([coords, coords[0]])
 
 
-def orient_linear_ring(coords: np.ndarray, exterior: bool) -> np.ndarray:
-    """Orient a GeoJSON linear ring to match requirement of RFC 7946 §3.1.6.
+def _orient_linear_ring(coords: np.ndarray, exterior: bool) -> np.ndarray:
+    """Orient a valid GeoJSON linear ring per RFC 7946 §3.1.6.
 
     In GeoJSON, the exterior ring of a polygon must be counterclockwise
     and holes must be clockwise.
     """
-    orientation = linear_ring_orientation(coords)
-
+    orientation = _linear_ring_orientation(coords)
     return coords if orientation == exterior else coords[::-1]
 
 
-def linear_ring_orientation(coords: np.ndarray) -> bool:
+def _linear_ring_orientation(coords: np.ndarray) -> bool:
     """Return the orientation of a closed linear ring in GeoJSON XY space.
 
     Uses the shoelace formula to compute the signed area:
@@ -129,7 +161,7 @@ def linear_ring_orientation(coords: np.ndarray) -> bool:
     return signed_area > 0
 
 
-def ellipse_to_polygon(coords: ArrayLike) -> np.ndarray:
+def _ellipse_to_polygon(coords: ArrayLike) -> np.ndarray:
     """Convert an ellipse to a polygon."""
     # TODO implement custom function
     # Hacky way to use napari's internal conversion

--- a/src/napari_geojson/_writer.py
+++ b/src/napari_geojson/_writer.py
@@ -51,10 +51,10 @@ def _get_geometry(coords: ArrayLike, shape_type: str) -> Polygon | LineString:
     """Convert napari coordinates to a GeoJSON geometry."""
     if shape_type == "ellipse":
         coords = _ellipse_to_polygon(coords)
-        return Polygon(coords.tolist())
+        return Polygon([_reverse_axis_order(coords).tolist()])
 
     if shape_type in ["rectangle", "polygon"]:
-        return Polygon([ring.tolist() for ring in get_polygon_rings(coords)])
+        return Polygon([ring.tolist() for ring in _get_polygon_rings(coords)])
 
     coords = _reverse_axis_order(coords).tolist()
 
@@ -63,12 +63,11 @@ def _get_geometry(coords: ArrayLike, shape_type: str) -> Polygon | LineString:
     raise ValueError(f"Shape type `{shape_type}` not supported.")
 
 
-def get_polygon_rings(coords: ArrayLike) -> list[np.ndarray]:
-    """Convert flat napari polygon vertices into GeoJSON linear rings.
+def _get_polygon_rings(coords: ArrayLike) -> list[np.ndarray]:
+    """Convert flat napari polygon vertices into oriented GeoJSON linear rings.
 
-    For polygons with holes, napari represents a polygon as a flat array of
-    vertices where each ring is terminated by repeating the first vertex.
-    GeoJSON requires separate linear rings: exterior first, then holes.
+    Splits the flat napari vertex array into rings, converts each to XY order, and
+    orients them per RFC 7946: exterior ring first, then any holes.
     """
     coords = np.atleast_2d(np.asarray(coords))
     return [
@@ -120,17 +119,14 @@ def _split_rings(coords: np.ndarray) -> list[np.ndarray]:
 
 def _close_linear_ring(coords: np.ndarray) -> np.ndarray:
     """Return a valid GeoJSON linear ring, closing it if needed."""
-    coords = np.atleast_2d(np.asarray(coords))
-    # Check if already closed
-    if np.array_equal(coords[0], coords[-1]):
-        if len(coords) < 4:
-            raise ValueError("GeoJSON linear rings require at least four positions.")
-        return coords
-
-    if len(coords) < 3:
-        raise ValueError("Polygon rings require at least three coordinates.")
-
-    return np.vstack([coords, coords[0]])
+    coords = np.asarray(coords)
+    if not np.array_equal(coords[0], coords[-1]):
+        coords = np.vstack([coords, coords[0]])
+    # A valid ring needs at least three distinct vertices plus the closing
+    # repeat of the first, i.e. four positions (RFC 7946 §3.1.6).
+    if len(coords) < 4:
+        raise ValueError("GeoJSON linear rings require at least four positions.")
+    return coords
 
 
 def _orient_linear_ring(coords: np.ndarray, exterior: bool) -> np.ndarray:

--- a/src/napari_geojson/_writer.py
+++ b/src/napari_geojson/_writer.py
@@ -50,6 +50,7 @@ def _reverse_axis_order(coords: ArrayLike) -> np.ndarray:
 def _get_geometry(coords: ArrayLike, shape_type: str) -> Polygon | LineString:
     """Convert napari coordinates to a GeoJSON geometry."""
     if shape_type == "ellipse":
+        # Ellipse handling will be reworked, see #21
         coords = _ellipse_to_polygon(coords)
         return Polygon([_reverse_axis_order(coords).tolist()])
 
@@ -66,12 +67,12 @@ def _get_geometry(coords: ArrayLike, shape_type: str) -> Polygon | LineString:
 def _get_polygon_rings(coords: ArrayLike) -> list[np.ndarray]:
     """Convert flat napari polygon vertices into oriented GeoJSON linear rings.
 
-    Splits the flat napari vertex array into rings, converts each to XY order, and
+    Converts the flat vertex array to XY order, splits it into rings, and
     orients them per RFC 7946: exterior ring first, then any holes.
     """
-    coords = np.atleast_2d(np.asarray(coords))
+    coords = _reverse_axis_order(np.atleast_2d(coords))
     return [
-        _orient_linear_ring(_reverse_axis_order(ring), exterior=index == 0)
+        _orient_linear_ring(ring, exterior=index == 0)
         for index, ring in enumerate(_split_rings(coords))
     ]
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3,7 +3,7 @@
 import geojson
 import numpy as np
 
-from napari_geojson._writer import write_shapes
+from napari_geojson._writer import linear_ring_orientation, write_shapes
 
 sample_shapes = [
     ([[0, 0], [0, 5], [5, 5], [5, 0]], "ellipse", "Polygon"),
@@ -68,3 +68,37 @@ def test_write_points_outputs_multipoint_feature(tmp_path):
         np.asarray(feature["geometry"]["coordinates"]),
         points[..., ::-1],
     )
+
+
+def test_write_polygon_with_hole(tmp_path):
+    """Writer writes valid GeoJSON polygon with an exterior ring and interior hole per RFC 7946.
+
+    Exterior ring should be counterclockwise and hole should be clockwise in GeoJSON XY space, regardless of the order of vertices in the napari input.
+    """
+    fname = tmp_path / "polygon_with_hole_oriented.geojson"
+    polygon = np.array(
+        [
+            [0, 0],
+            [10, 0],
+            [10, 10],
+            [0, 10],
+            [0, 0],
+            [2, 2],
+            [2, 4],
+            [4, 4],
+            [4, 2],
+            [2, 2],
+        ]
+    )
+    layer_data = [([polygon], {"shape_type": ["polygon"]}, "shapes")]
+
+    write_shapes(str(fname), layer_data)
+
+    with open(fname) as fp:
+        collection = geojson.load(fp)
+
+    exterior, hole = [
+        np.asarray(ring) for ring in collection.features[0]["geometry"]["coordinates"]
+    ]
+    assert linear_ring_orientation(exterior)
+    assert not linear_ring_orientation(hole)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,9 +1,18 @@
 """Tests for the writer part of the plugin."""
 
+import warnings
+
 import geojson
 import numpy as np
+import pytest
 
-from napari_geojson._writer import linear_ring_orientation, write_shapes
+from napari_geojson._writer import (
+    _close_linear_ring,
+    _linear_ring_orientation,
+    _orient_linear_ring,
+    _split_rings,
+    write_shapes,
+)
 
 sample_shapes = [
     ([[0, 0], [0, 5], [5, 5], [5, 0]], "ellipse", "Polygon"),
@@ -100,5 +109,102 @@ def test_write_polygon_with_hole(tmp_path):
     exterior, hole = [
         np.asarray(ring) for ring in collection.features[0]["geometry"]["coordinates"]
     ]
-    assert linear_ring_orientation(exterior)
-    assert not linear_ring_orientation(hole)
+    assert _linear_ring_orientation(exterior)
+    assert not _linear_ring_orientation(hole)
+
+
+def test_split_rings_ignores_trailing_path_terminator():
+    """Split rings should ignore a final path closing vertex."""
+    polygon = np.array(
+        [
+            [0, 0],
+            [3, 0],
+            [3, 3],
+            [0, 3],
+            [0, 0],
+            [1, 1],
+            [2, 1],
+            [2, 2],
+            [1, 2],
+            [1, 1],
+            [0, 0],
+        ]
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        exterior, hole = _split_rings(polygon)
+
+    assert not caught
+
+    np.testing.assert_array_equal(
+        exterior,
+        np.array([[0, 0], [3, 0], [3, 3], [0, 3], [0, 0]]),
+    )
+    np.testing.assert_array_equal(
+        hole,
+        np.array([[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]]),
+    )
+
+
+def test_close_linear_ring_rejects_three_position_closed_ring():
+    """Close ring should reject already-closed rings with only three positions."""
+    ring = np.array([[0, 0], [1, 0], [0, 0]])
+
+    with pytest.raises(ValueError, match="at least four positions"):
+        _close_linear_ring(ring)
+
+
+@pytest.mark.parametrize("exterior", [True, False])
+def test_orient_linear_ring_orients_closed_ring(exterior):
+    """Orient ring should preserve closure and apply the requested winding."""
+    ring = np.array([[0, 0], [0, 1], [1, 0], [0, 0]])
+
+    oriented = _orient_linear_ring(ring, exterior=exterior)
+
+    np.testing.assert_array_equal(oriented[0], oriented[-1])
+    assert len(oriented) == 4
+    assert _linear_ring_orientation(oriented) == exterior
+
+
+@pytest.mark.parametrize(
+    "trailing_vertices",
+    [
+        np.array([[0, 4]]),
+        np.array([[0, 4], [1, 5]]),
+        np.array([[0, 4], [1, 5], [2, 4]]),
+    ],
+)
+def test_split_rings_warns_and_trims_trailing_vertices(trailing_vertices):
+    """Split rings should warn and trim trailing vertices after closed rings."""
+    polygon = np.vstack(
+        [
+            np.array(
+                [
+                    [0, 0],
+                    [3, 0],
+                    [3, 3],
+                    [0, 3],
+                    [0, 0],
+                    [1, 1],
+                    [2, 1],
+                    [2, 2],
+                    [1, 2],
+                    [1, 1],
+                ]
+            ),
+            trailing_vertices,
+        ]
+    )
+
+    with pytest.warns(UserWarning, match="Ignoring trailing polygon vertices"):
+        exterior, hole = _split_rings(polygon)
+
+    np.testing.assert_array_equal(
+        exterior,
+        np.array([[0, 0], [3, 0], [3, 3], [0, 3], [0, 0]]),
+    )
+    np.testing.assert_array_equal(
+        hole,
+        np.array([[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]]),
+    )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -23,6 +23,11 @@ sample_shapes = [
     ([[0, 0], [5, 5], [0, 10]], "path", "LineString"),
 ]
 
+# Closed exterior ring and hole shared by the _split_rings trailing-vertex tests.
+EXTERIOR_RING = np.array([[0, 0], [3, 0], [3, 3], [0, 3], [0, 0]])
+HOLE_RING = np.array([[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]])
+POLYGON_WITH_HOLE = np.vstack([EXTERIOR_RING, HOLE_RING])
+
 
 def test_write_shapes_outputs_feature_collection(tmp_path):
     """Writer writes standard GeoJSON Features inside one FeatureCollection."""
@@ -143,21 +148,7 @@ def test_write_polygon_with_hole(tmp_path):
 
 def test_split_rings_ignores_trailing_path_terminator():
     """Split rings should ignore a final path closing vertex."""
-    polygon = np.array(
-        [
-            [0, 0],
-            [3, 0],
-            [3, 3],
-            [0, 3],
-            [0, 0],
-            [1, 1],
-            [2, 1],
-            [2, 2],
-            [1, 2],
-            [1, 1],
-            [0, 0],
-        ]
-    )
+    polygon = np.vstack([POLYGON_WITH_HOLE, [0, 0]])
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -165,14 +156,8 @@ def test_split_rings_ignores_trailing_path_terminator():
 
     assert not caught
 
-    np.testing.assert_array_equal(
-        exterior,
-        np.array([[0, 0], [3, 0], [3, 3], [0, 3], [0, 0]]),
-    )
-    np.testing.assert_array_equal(
-        hole,
-        np.array([[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]]),
-    )
+    np.testing.assert_array_equal(exterior, EXTERIOR_RING)
+    np.testing.assert_array_equal(hole, HOLE_RING)
 
 
 def test_close_linear_ring_rejects_three_position_closed_ring():
@@ -205,34 +190,10 @@ def test_orient_linear_ring_orients_closed_ring(exterior):
 )
 def test_split_rings_warns_and_trims_trailing_vertices(trailing_vertices):
     """Split rings should warn and trim trailing vertices after closed rings."""
-    polygon = np.vstack(
-        [
-            np.array(
-                [
-                    [0, 0],
-                    [3, 0],
-                    [3, 3],
-                    [0, 3],
-                    [0, 0],
-                    [1, 1],
-                    [2, 1],
-                    [2, 2],
-                    [1, 2],
-                    [1, 1],
-                ]
-            ),
-            trailing_vertices,
-        ]
-    )
+    polygon = np.vstack([POLYGON_WITH_HOLE, trailing_vertices])
 
     with pytest.warns(UserWarning, match="Ignoring trailing polygon vertices"):
         exterior, hole = _split_rings(polygon)
 
-    np.testing.assert_array_equal(
-        exterior,
-        np.array([[0, 0], [3, 0], [3, 3], [0, 3], [0, 0]]),
-    )
-    np.testing.assert_array_equal(
-        hole,
-        np.array([[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]]),
-    )
+    np.testing.assert_array_equal(exterior, EXTERIOR_RING)
+    np.testing.assert_array_equal(hole, HOLE_RING)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -8,6 +8,7 @@ import pytest
 
 from napari_geojson._writer import (
     _close_linear_ring,
+    _ellipse_to_polygon,
     _linear_ring_orientation,
     _orient_linear_ring,
     _split_rings,
@@ -77,6 +78,33 @@ def test_write_points_outputs_multipoint_feature(tmp_path):
         np.asarray(feature["geometry"]["coordinates"]),
         points[..., ::-1],
     )
+
+
+def test_write_ellipse_outputs_single_xy_ring(tmp_path):
+    """Ellipse writes one linear ring in GeoJSON XY order.
+
+    Uses an asymmetric bounding box so XY differs from napari's YX order.
+    """
+    fname = tmp_path / "ellipse.geojson"
+    # napari YX bounding box: axis0 (rows) span 0-10, axis1 (cols) span 0-4
+    ellipse = np.array([[0, 0], [0, 4], [10, 4], [10, 0]])
+    layer_data = [([ellipse], {"shape_type": ["ellipse"]}, "shapes")]
+
+    write_shapes(str(fname), layer_data)
+
+    with open(fname) as fp:
+        collection = geojson.load(fp)
+
+    coordinates = collection.features[0]["geometry"]["coordinates"]
+    # A single linear ring, not one ring per vertex
+    assert len(coordinates) == 1
+    ring = np.asarray(coordinates[0])
+    # Output is the ellipse polygon with napari YX reversed to GeoJSON XY
+    # (atol accounts for geojson rounding coordinates on serialization).
+    expected = _ellipse_to_polygon(ellipse)[:, ::-1]
+    np.testing.assert_allclose(ring, expected, atol=1e-6)
+    # closed ring
+    np.testing.assert_array_equal(ring[0], ring[-1])
 
 
 def test_write_polygon_with_hole(tmp_path):


### PR DESCRIPTION
Closes: https://github.com/napari/napari-geojson/issues/9

This PR refactors writing to ensure that the flat arrays of vertexes from napari are split into rings.
GeoJSON requires that the first ring be the exterior ring and that the vertexes be ordered counterclockwise and the remaining be the holes and the vertexes be ordered clockwise.
I used copilot Claude Sonnet to review my work and it suggested using the signed area to determine vertex order and be sure that order is fixed when needed. I liked that and tweaked things a bit after.

With this PR, the `polygon_with_hole.json` form the test set can be round tripped as valid GeoJSON.
Also I tested that polygons with holes from QuPath can be saved back out and imported into QuPath.
